### PR TITLE
Export incorporate to enable Cycle React JSX pragma

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,5 @@ export {ScopeContext} from './context';
 export {Scope} from './scope';
 export {ReactSource} from './ReactSource';
 export {h} from './h';
+export {incorporate} from './incorporate';
 export {StreamRenderer} from './StreamRenderer';


### PR DESCRIPTION
## Summary

I'm working on a [pragma](https://github.com/sliptype/cycle-react-pragma) to support JSX when rendering React components in Cycle.

To support the MVI architecture and the special `sel` prop I need access to `incorporate`.

## Changes

- Export `incorporate` from `./incorporate` in `src/index.ts`